### PR TITLE
Add support for message reactions and reaction count updates

### DIFF
--- a/fptelegram.lpk
+++ b/fptelegram.lpk
@@ -23,7 +23,7 @@
     </CompilerOptions>
     <Description Value="Telegram bots API library"/>
     <License Value="MIT License"/>
-    <Version Release="7"/>
+    <Version Release="8"/>
     <Files Count="6">
       <Item1>
         <Filename Value="tgsendertypes.pas"/>

--- a/test/testtelegram.pas
+++ b/test/testtelegram.pas
@@ -76,6 +76,14 @@ type
     procedure sendMessage;
   end;
 
+  { TTestReactionUpdates }
+
+  TTestReactionUpdates=class(TTestCase)
+  published
+    procedure ParseMessageReactionUpdate;
+    procedure ParseMessageReactionCountUpdate;
+  end;
+
   { TTestReceiveLongPollingBase }
   { Test receiving updates via longpolling from the test bot. Please send test messages to the bot
     immediately before running the test! }
@@ -269,6 +277,93 @@ begin
   if not TgBotSendMessage(AToken, AChatID, Format(Msg, [Self.ClassName, TestName]), AReply) then
     Fail('Fail to send message from telegram bot!');
   SaveString(AReply, '~JSONResponce.json');
+end;
+
+{ TTestReactionUpdates }
+
+procedure TTestReactionUpdates.ParseMessageReactionUpdate;
+const
+  ReactionUpdateJSON =
+    '{' +
+      '"update_id":1000,' +
+      '"message_reaction":{' +
+        '"chat":{"id":42,"type":"private","first_name":"Test"},' +
+        '"message_id":7,' +
+        '"user":{"id":99,"is_bot":false,"first_name":"Bob"},' +
+        '"date":1700000000,' +
+        '"old_reaction":[{"type":"emoji","emoji":"👍"}],' +
+        '"new_reaction":[{"type":"custom_emoji","custom_emoji_id":"abc123"}]' +
+      '}' +
+    '}';
+var
+  UpdateObj: TTelegramUpdateObj;
+  ReactionUpdate: TTelegramMessageReactionUpdated;
+  JSONData: TJSONData;
+begin
+  JSONData:=GetJSON(ReactionUpdateJSON);
+  try
+    UpdateObj:=TTelegramUpdateObj.Create(JSONData as TJSONObject);
+    try
+      AssertEquals(utMessageReaction, UpdateObj.UpdateType);
+      ReactionUpdate:=UpdateObj.MessageReaction;
+      AssertNotNull('MessageReaction should be assigned', ReactionUpdate);
+      AssertEquals(42, ReactionUpdate.Chat.ID);
+      AssertEquals(7, ReactionUpdate.MessageID);
+      AssertNotNull('MessageReaction user should be assigned', ReactionUpdate.User);
+      AssertEquals(99, ReactionUpdate.User.ID);
+      AssertEquals(1, ReactionUpdate.OldReactions.Count);
+      AssertEquals('emoji', ReactionUpdate.OldReactions[0].TypeName);
+      AssertEquals('👍', ReactionUpdate.OldReactions[0].Emoji);
+      AssertEquals(1, ReactionUpdate.NewReactions.Count);
+      AssertEquals('custom_emoji', ReactionUpdate.NewReactions[0].TypeName);
+      AssertEquals('abc123', ReactionUpdate.NewReactions[0].CustomEmojiID);
+    finally
+      UpdateObj.Free;
+    end;
+  finally
+    JSONData.Free;
+  end;
+end;
+
+procedure TTestReactionUpdates.ParseMessageReactionCountUpdate;
+const
+  ReactionCountUpdateJSON =
+    '{' +
+      '"update_id":1001,' +
+      '"message_reaction_count":{' +
+        '"chat":{"id":123,"type":"supergroup","title":"Test Group"},' +
+        '"message_id":10,' +
+        '"date":1700000100,' +
+        '"reactions":[{' +
+          '"type":{"type":"emoji","emoji":"❤️"},' +
+          '"total_count":3' +
+        '}]' +
+      '}' +
+    '}';
+var
+  UpdateObj: TTelegramUpdateObj;
+  ReactionCountUpdate: TTelegramMessageReactionCountUpdated;
+  JSONData: TJSONData;
+begin
+  JSONData:=GetJSON(ReactionCountUpdateJSON);
+  try
+    UpdateObj:=TTelegramUpdateObj.Create(JSONData as TJSONObject);
+    try
+      AssertEquals(utMessageReactionCount, UpdateObj.UpdateType);
+      ReactionCountUpdate:=UpdateObj.MessageReactionCount;
+      AssertNotNull('MessageReactionCount should be assigned', ReactionCountUpdate);
+      AssertEquals(123, ReactionCountUpdate.Chat.ID);
+      AssertEquals(10, ReactionCountUpdate.MessageID);
+      AssertEquals(1, ReactionCountUpdate.Reactions.Count);
+      AssertEquals(3, ReactionCountUpdate.Reactions[0].TotalCount);
+      AssertEquals('emoji', ReactionCountUpdate.Reactions[0].ReactionType.TypeName);
+      AssertEquals('❤️', ReactionCountUpdate.Reactions[0].ReactionType.Emoji);
+    finally
+      UpdateObj.Free;
+    end;
+  finally
+    JSONData.Free;
+  end;
 end;
 
 { TTestSender }
@@ -597,7 +692,7 @@ begin
 end;
 
 initialization
-  RegisterTests([TTestSender, TTestSenderProcedure, TTestProxySender, TTestReceiveLongPolling, TTestPayments]);
+  RegisterTests([TTestSender, TTestSenderProcedure, TTestProxySender, TTestReceiveLongPolling,
+    TTestPayments, TTestReactionUpdates]);
 
 end.
-

--- a/test/testtelegram.pas
+++ b/test/testtelegram.pas
@@ -1,6 +1,7 @@
 unit testtelegram;
 
 {$mode objfpc}{$H+}
+{$codepage UTF8}
 
 interface
 
@@ -304,7 +305,7 @@ begin
   try
     UpdateObj:=TTelegramUpdateObj.Create(JSONData as TJSONObject);
     try
-      AssertEquals(utMessageReaction, UpdateObj.UpdateType);
+      AssertEquals(Ord(utMessageReaction), Ord(UpdateObj.UpdateType));
       ReactionUpdate:=UpdateObj.MessageReaction;
       AssertNotNull('MessageReaction should be assigned', ReactionUpdate);
       AssertEquals(42, ReactionUpdate.Chat.ID);
@@ -312,10 +313,10 @@ begin
       AssertNotNull('MessageReaction user should be assigned', ReactionUpdate.User);
       AssertEquals(99, ReactionUpdate.User.ID);
       AssertEquals(1, ReactionUpdate.OldReactions.Count);
-      AssertEquals('emoji', ReactionUpdate.OldReactions[0].TypeName);
+      AssertEquals(Ord(rtReactionTypeEmoji), Ord(ReactionUpdate.OldReactions[0].TypeEnum));
       AssertEquals('👍', ReactionUpdate.OldReactions[0].Emoji);
       AssertEquals(1, ReactionUpdate.NewReactions.Count);
-      AssertEquals('custom_emoji', ReactionUpdate.NewReactions[0].TypeName);
+      AssertEquals(Ord(rtReactionTypeCustomEmoji), Ord(ReactionUpdate.NewReactions[0].TypeEnum));
       AssertEquals('abc123', ReactionUpdate.NewReactions[0].CustomEmojiID);
     finally
       UpdateObj.Free;
@@ -341,28 +342,28 @@ const
       '}' +
     '}';
 var
-  UpdateObj: TTelegramUpdateObj;
-  ReactionCountUpdate: TTelegramMessageReactionCountUpdated;
-  JSONData: TJSONData;
+  aUpdateObj: TTelegramUpdateObj;
+  aReactionCountUpdate: TTelegramMessageReactionCountUpdated;
+  aJSONData: TJSONData;
 begin
-  JSONData:=GetJSON(ReactionCountUpdateJSON);
+  aJSONData:=GetJSON(ReactionCountUpdateJSON);
   try
-    UpdateObj:=TTelegramUpdateObj.Create(JSONData as TJSONObject);
+    aUpdateObj:=TTelegramUpdateObj.Create(aJSONData as TJSONObject);
     try
-      AssertEquals(utMessageReactionCount, UpdateObj.UpdateType);
-      ReactionCountUpdate:=UpdateObj.MessageReactionCount;
-      AssertNotNull('MessageReactionCount should be assigned', ReactionCountUpdate);
-      AssertEquals(123, ReactionCountUpdate.Chat.ID);
-      AssertEquals(10, ReactionCountUpdate.MessageID);
-      AssertEquals(1, ReactionCountUpdate.Reactions.Count);
-      AssertEquals(3, ReactionCountUpdate.Reactions[0].TotalCount);
-      AssertEquals('emoji', ReactionCountUpdate.Reactions[0].ReactionType.TypeName);
-      AssertEquals('❤️', ReactionCountUpdate.Reactions[0].ReactionType.Emoji);
+      AssertEquals(Ord(utMessageReactionCount), Ord(aUpdateObj.UpdateType));
+      aReactionCountUpdate:=aUpdateObj.MessageReactionCount;
+      AssertNotNull('MessageReactionCount should be assigned', aReactionCountUpdate);
+      AssertEquals(123, aReactionCountUpdate.Chat.ID);
+      AssertEquals(10, aReactionCountUpdate.MessageID);
+      AssertEquals(1, aReactionCountUpdate.Reactions.Count);
+      AssertEquals(3, aReactionCountUpdate.Reactions[0].TotalCount);
+      AssertEquals(Ord(rtReactionTypeEmoji), Ord(aReactionCountUpdate.Reactions[0].ReactionType.TypeEnum));
+      AssertEquals('❤️', aReactionCountUpdate.Reactions[0].ReactionType.Emoji);
     finally
-      UpdateObj.Free;
+      aUpdateObj.Free;
     end;
   finally
-    JSONData.Free;
+    aJSONData.Free;
   end;
 end;
 

--- a/tgsendertypes.pas
+++ b/tgsendertypes.pas
@@ -36,6 +36,10 @@ type
     APreCheckoutQuery: TTelegramPreCheckOutQuery) of object;
   TSuccessfulPaymentEvent = procedure (ASender: TObject;
     ASuccessfulPayment: TTelegramSuccessfulPayment) of object;
+  TMessageReactionEvent = procedure (ASender: TObject;
+    AMessageReaction: TTelegramMessageReactionUpdated) of object;
+  TMessageReactionCountEvent = procedure (ASender: TObject;
+    AMessageReactionCount: TTelegramMessageReactionCountUpdated) of object;
 
   { TStringHash }
 
@@ -451,6 +455,8 @@ type
     FOnReceiveEditedMessage: TMessageEvent;
     FOnReceiveInlineQuery: TInlineQueryEvent;
     FOnReceiveMessage: TMessageEvent;
+    FOnReceiveMessageReaction: TMessageReactionEvent;
+    FOnReceiveMessageReactionCount: TMessageReactionCountEvent;
     FOnReceiveMyChatMemberUpdated: TChatMemberEvent;
     FOnReceivePreCheckoutQuery: TPreCheckoutQueryEvent;
     FOnReceiveSuccessfulPayment: TMessageEvent;
@@ -527,6 +533,8 @@ type
     procedure DoReceivePreCheckoutQuery(APreCheckoutQuery: TTelegramPreCheckOutQuery); virtual;  
     procedure DoReceiveMyChatMemberQuery(AMyChatMember: TTelegramChatMemberUpdated); virtual;
     procedure DoReceiveChatMemberQuery(AChatMember: TTelegramChatMemberUpdated); virtual;
+    procedure DoReceiveMessageReaction(AMessageReaction: TTelegramMessageReactionUpdated); virtual;
+    procedure DoReceiveMessageReactionCount(AMessageReactionCount: TTelegramMessageReactionCountUpdated); virtual;
     procedure DoReceiveSuccessfulPayment(AMessage: TTelegramMessageObj); virtual;  
     procedure DoReceiveBusinessConnection(ABusinessConnection: TTelegramBusinessConnectionObj); virtual; 
     procedure DoReceiveBusinessMessage(ABusinessMessage: TTelegramMessageObj); virtual;
@@ -743,7 +751,11 @@ type
     property OnReceiveBusinessConnection: TBusinessConnectionEvent read FOnReceiveBusinessConnection
       write FOnReceiveBusinessConnection;
     property OnReceiveBusinessMessage: TMessageEvent read FOnReceiveBusinessMessage
-      write FOnReceiveBusinessMessage;    
+      write FOnReceiveBusinessMessage;
+    property OnReceiveMessageReaction: TMessageReactionEvent read FOnReceiveMessageReaction
+      write FOnReceiveMessageReaction;
+    property OnReceiveMessageReactionCount: TMessageReactionCountEvent read FOnReceiveMessageReactionCount
+      write FOnReceiveMessageReactionCount;
     property OnReceiveMyChatMemberUpdated: TChatMemberEvent read FOnReceiveMyChatMemberUpdated
       write FOnReceiveMyChatMemberUpdated;
     property OnReceiveChatMemberUpdated: TChatMemberEvent read FOnReceiveChatMemberUpdated
@@ -2282,6 +2294,38 @@ begin
     FOnReceiveChatMemberUpdated(Self, AChatMember);
 end;
 
+procedure TTelegramSender.DoReceiveMessageReaction(
+  AMessageReaction: TTelegramMessageReactionUpdated);
+begin
+  FCurrentMessage:=nil;
+  FCurrentChat:=AMessageReaction.Chat;
+  FCurrentChatID:=AMessageReaction.Chat.ID;
+  FCurrentThreadId:=_nullThrd;
+  FCurrentIsTopicMessage:=False;
+  FCurrentUser:=AMessageReaction.User;
+  if CurrentIsBanned then
+    Exit;
+  DoAfterParseUpdate;
+  if Assigned(FOnReceiveMessageReaction) then
+    FOnReceiveMessageReaction(Self, AMessageReaction);
+end;
+
+procedure TTelegramSender.DoReceiveMessageReactionCount(
+  AMessageReactionCount: TTelegramMessageReactionCountUpdated);
+begin
+  FCurrentMessage:=nil;
+  FCurrentChat:=AMessageReactionCount.Chat;
+  FCurrentChatID:=AMessageReactionCount.Chat.ID;
+  FCurrentThreadId:=_nullThrd;
+  FCurrentIsTopicMessage:=False;
+  FCurrentUser:=nil;
+  if CurrentIsBanned then
+    Exit;
+  DoAfterParseUpdate;
+  if Assigned(FOnReceiveMessageReactionCount) then
+    FOnReceiveMessageReactionCount(Self, AMessageReactionCount);
+end;
+
 procedure TTelegramSender.DoReceiveSuccessfulPayment(
   AMessage: TTelegramMessageObj);
 begin
@@ -2354,6 +2398,8 @@ begin
         utChatMember:         DoReceiveChatMemberQuery(AnUpdate.ChatMember);
         utBusinessConnection: DoReceiveBusinessConnection(AnUpdate.BusinessConnection);
         utBusinessMessage:    DoReceiveBusinessMessage(AnUpdate.BusinessMessage);
+        utMessageReaction:    DoReceiveMessageReaction(AnUpdate.MessageReaction);
+        utMessageReactionCount: DoReceiveMessageReactionCount(AnUpdate.MessageReactionCount);
       end;
       if Assigned(FUpdateLogger) then
         if CurrentIsSimpleUser then  // This is to ensure that admins and moderators do not affect the statistics

--- a/tgtypes.pas
+++ b/tgtypes.pas
@@ -195,21 +195,28 @@ type
     property Data: String read FData;  // optional 1-64 bytes!!!
   end;
 
+  TReactionType = (rtNone, rtReactionTypeEmoji, rtReactionTypeCustomEmoji, rtReactionTypePaid);
+
   { TTelegramReactionType }
 
   TTelegramReactionType = class(TTelegramObj)
   private
-    FTypeName: String;
+    FTypeEnum: TReactionType;
     FEmoji: String;
     FCustomEmojiID: String;
   public
     constructor Create(JSONObject: TJSONObject); override;
-    property TypeName: String read FTypeName;
+    property TypeEnum: TReactionType read FTypeEnum;
     property Emoji: String read FEmoji;
     property CustomEmojiID: String read FCustomEmojiID;
   end;
 
-  TTelegramReactionTypeList = specialize TFPGObjectList<TTelegramReactionType>;
+  { TTelegramReactionTypeList }
+
+  TTelegramReactionTypeList = class(specialize TFPGObjectList<TTelegramReactionType>)
+  public
+    function CommaString: String;
+  end;
 
   { TTelegramReactionCount }
 
@@ -678,6 +685,8 @@ const
   s_MsgThrdID ='message_thread_id';
   s_BsnsCnctnID='business_connection_id';
 
+  _ReactionTypeStrings: array[TReactionType] of String = ('', 'emoji', 'custom_emoji', 'paid');
+
 function AllowedUpdatesToJSON(const AllowedUpdates: TUpdateSet): TJSONArray;
 var
   u: TUpdateType;
@@ -701,6 +710,17 @@ begin
   end;
   if Result=[] then
     Result:=utAllUpdates;
+end;
+
+function StringToReactionType(const aReactionType: String): TReactionType;
+var
+  i: Integer;
+begin
+  i:=IndexStr(aReactionType, _ReactionTypeStrings);
+  if i>-1 then
+    Result:=TReactionType(i)
+  else
+    Result:=rtNone;
 end;
 
 { TTelegramBaseChat }
@@ -1083,9 +1103,23 @@ end;
 constructor TTelegramReactionType.Create(JSONObject: TJSONObject);
 begin
   inherited Create(JSONObject);
-  FTypeName:=fJSON.Get('type', EmptyStr);
+  FTypeEnum:=StringToReactionType(fJSON.Strings['type']);
   FEmoji:=fJSON.Get('emoji', EmptyStr);
   FCustomEmojiID:=fJSON.Get('custom_emoji_id', EmptyStr);
+end;
+
+{ TTelegramReactionTypeList }
+
+function TTelegramReactionTypeList.CommaString: String;
+var
+  aReactionType: TTelegramReactionType;
+  aDelim: String = ', ';
+begin
+  Result:=EmptyStr;
+  for aReactionType in Self do
+    Result+=aReactionType.Emoji+aDelim;
+  if Length(Result)>=Length(aDelim) then
+    SetLength(Result, Length(Result)-Length(aDelim));
 end;
 
 { TTelegramReactionCount }
@@ -1110,13 +1144,17 @@ constructor TTelegramMessageReactionUpdated.Create(JSONObject: TJSONObject);
 var
   lJSONArray: TJSONArray;
   lJSONEnum: TJSONEnum;
+  aUser, aActorChat: TJSONObject;
 begin
   inherited Create(JSONObject);
   FMessageID:=fJSON.Integers['message_id'];
   FDate:=fJSON.Int64s['date'];
   FChat:=TTelegramChatObj.CreateFromJSONObject(fJSON.Find('chat', jtObject) as TJSONObject) as TTelegramChatObj;
-  FUser:=TTelegramUserObj.CreateFromJSONObject(fJSON.Find('user', jtObject) as TJSONObject) as TTelegramUserObj;
-  FActorChat:=TTelegramChatObj.CreateFromJSONObject(fJSON.Find('actor_chat', jtObject) as TJSONObject) as TTelegramChatObj;
+  aUser:=fJSON.Find('user', jtObject) as TJSONObject;
+  if Assigned(aUser) then
+    FUser:=TTelegramUserObj.CreateFromJSONObject(aUser) as TTelegramUserObj;
+  aActorChat:=fJSON.Find('actor_chat', jtObject) as TJSONObject;
+  FActorChat:=TTelegramChatObj.CreateFromJSONObject(aActorChat) as TTelegramChatObj;
   FOldReactions:=TTelegramReactionTypeList.Create;
   FNewReactions:=TTelegramReactionTypeList.Create;
 

--- a/tgtypes.pas
+++ b/tgtypes.pas
@@ -30,10 +30,14 @@ type
   TTelegramVoice = class;
   TTelegramAudio = class;
   TTelegramDocument = class;
+  TTelegramReactionType = class;
+  TTelegramReactionCount = class;
+  TTelegramMessageReactionUpdated = class;
+  TTelegramMessageReactionCountUpdated = class;
 
   TUpdateType = (utMessage, utEditedMessage, utChannelPost, utEditedChannelPost, utInlineQuery,
     utChosenInlineResult, utCallbackQuery, utShippingQuery, utPreCheckoutQuery, utMyChatMember, utChatMember,
-    utBusinessConnection, utBusinessMessage, utUnknown);
+    utBusinessConnection, utBusinessMessage, utMessageReaction, utMessageReactionCount, utUnknown);
   TChatType = (ctPrivate, ctGroup, ctSuperGroup, ctChannel, ctUnknown);
   TChatMemberStatus = (msCreator, msAdministrator, msMember, msRestricted, msLeft, msKicked, msUnknown);
   TUpdateSet = set of TUpdateType;
@@ -69,6 +73,8 @@ type
     function GetEditedMessage: TTelegramMessageObj;
     function GetInlineQuery: TTelegramInlineQueryObj;
     function GetMessage: TTelegramMessageObj;
+    function GetMessageReaction: TTelegramMessageReactionUpdated;
+    function GetMessageReactionCount: TTelegramMessageReactionCountUpdated;
     function GetMyChatMember: TTelegramChatMemberUpdated;
     function GetPreCheckoutQuery: TTelegramPreCheckOutQuery;
     function ParseUpdateParameter: TUpdateType;
@@ -88,6 +94,8 @@ type
     property PreCheckoutQuery: TTelegramPreCheckOutQuery read GetPreCheckoutQuery;
     property BusinessConnection: TTelegramBusinessConnectionObj read GetBusinessConnection; 
     property BusinessMessage: TTelegramMessageObj read GetBusinessMessage;   
+    property MessageReaction: TTelegramMessageReactionUpdated read GetMessageReaction;
+    property MessageReactionCount: TTelegramMessageReactionCountUpdated read GetMessageReactionCount;
     property MyChatMember: TTelegramChatMemberUpdated read GetMyChatMember;
     property ChatMember: TTelegramChatMemberUpdated read GetChatMember;
   end;
@@ -185,6 +193,77 @@ type
     property Message: TTelegramMessageObj read FMessage;
     property ChatInstance: String read FChatInstance;
     property Data: String read FData;  // optional 1-64 bytes!!!
+  end;
+
+  { TTelegramReactionType }
+
+  TTelegramReactionType = class(TTelegramObj)
+  private
+    FTypeName: String;
+    FEmoji: String;
+    FCustomEmojiID: String;
+  public
+    constructor Create(JSONObject: TJSONObject); override;
+    property TypeName: String read FTypeName;
+    property Emoji: String read FEmoji;
+    property CustomEmojiID: String read FCustomEmojiID;
+  end;
+
+  TTelegramReactionTypeList = specialize TFPGObjectList<TTelegramReactionType>;
+
+  { TTelegramReactionCount }
+
+  TTelegramReactionCount = class(TTelegramObj)
+  private
+    FReactionType: TTelegramReactionType;
+    FTotalCount: Integer;
+  public
+    constructor Create(JSONObject: TJSONObject); override;
+    destructor Destroy; override;
+    property ReactionType: TTelegramReactionType read FReactionType;
+    property TotalCount: Integer read FTotalCount;
+  end;
+
+  TTelegramReactionCountList = specialize TFPGObjectList<TTelegramReactionCount>;
+
+  { TTelegramMessageReactionUpdated }
+
+  TTelegramMessageReactionUpdated = class(TTelegramObj)
+  private
+    FChat: TTelegramChatObj;
+    FMessageID: Integer;
+    FUser: TTelegramUserObj;
+    FActorChat: TTelegramChatObj;
+    FDate: Int64;
+    FOldReactions: TTelegramReactionTypeList;
+    FNewReactions: TTelegramReactionTypeList;
+  public
+    constructor Create(JSONObject: TJSONObject); override;
+    destructor Destroy; override;
+    property Chat: TTelegramChatObj read FChat;
+    property MessageID: Integer read FMessageID;
+    property User: TTelegramUserObj read FUser;
+    property ActorChat: TTelegramChatObj read FActorChat;
+    property Date: Int64 read FDate;
+    property OldReactions: TTelegramReactionTypeList read FOldReactions;
+    property NewReactions: TTelegramReactionTypeList read FNewReactions;
+  end;
+
+  { TTelegramMessageReactionCountUpdated }
+
+  TTelegramMessageReactionCountUpdated = class(TTelegramObj)
+  private
+    FChat: TTelegramChatObj;
+    FMessageID: Integer;
+    FDate: Int64;
+    FReactions: TTelegramReactionCountList;
+  public
+    constructor Create(JSONObject: TJSONObject); override;
+    destructor Destroy; override;
+    property Chat: TTelegramChatObj read FChat;
+    property MessageID: Integer read FMessageID;
+    property Date: Int64 read FDate;
+    property Reactions: TTelegramReactionCountList read FReactions;
   end;
 
   { TTelegramBusinessConnectionObj }
@@ -570,11 +649,12 @@ type
     UpdateTypeAliases: array[TUpdateType] of String = ('message', 'edited_message', 'channel_post',
       'edited_channel_post', 'inline_query', 'chosen_inline_result', 'callback_query',
       'shipping_query', 'pre_checkout_query', 'my_chat_member', 'chat_member', 'business_connection',
-      'business_message', '');
+      'business_message', 'message_reaction', 'message_reaction_count', '');
     UpdateTypeClasses: array[TUpdateType] of TTelegramObjClass = (TTelegramMessageObj, TTelegramMessageObj,
       TTelegramMessageObj, TTelegramMessageObj, TTelegramInlineQueryObj, TTelegramChosenInlineResultObj,
       TCallbackQueryObj, TTelegramObj, TTelegramPreCheckOutQuery, TTelegramChatMemberUpdated,
-      TTelegramChatMemberUpdated, TTelegramBusinessConnectionObj, TTelegramMessageObj, TTelegramObj);
+      TTelegramChatMemberUpdated, TTelegramBusinessConnectionObj, TTelegramMessageObj,
+      TTelegramMessageReactionUpdated, TTelegramMessageReactionCountUpdated, TTelegramObj);
     _nullThrd = 0;
 
 function AllowedUpdatesToJSON(const AllowedUpdates: TUpdateSet): TJSONArray;
@@ -998,6 +1078,98 @@ begin
   inherited Destroy;
 end;
 
+{ TTelegramReactionType }
+
+constructor TTelegramReactionType.Create(JSONObject: TJSONObject);
+begin
+  inherited Create(JSONObject);
+  FTypeName:=fJSON.Get('type', EmptyStr);
+  FEmoji:=fJSON.Get('emoji', EmptyStr);
+  FCustomEmojiID:=fJSON.Get('custom_emoji_id', EmptyStr);
+end;
+
+{ TTelegramReactionCount }
+
+constructor TTelegramReactionCount.Create(JSONObject: TJSONObject);
+begin
+  inherited Create(JSONObject);
+  FReactionType:=TTelegramReactionType.CreateFromJSONObject(
+    fJSON.Find('type', jtObject) as TJSONObject) as TTelegramReactionType;
+  FTotalCount:=fJSON.Get('total_count', 0);
+end;
+
+destructor TTelegramReactionCount.Destroy;
+begin
+  FReactionType.Free;
+  inherited Destroy;
+end;
+
+{ TTelegramMessageReactionUpdated }
+
+constructor TTelegramMessageReactionUpdated.Create(JSONObject: TJSONObject);
+var
+  lJSONArray: TJSONArray;
+  lJSONEnum: TJSONEnum;
+begin
+  inherited Create(JSONObject);
+  FMessageID:=fJSON.Integers['message_id'];
+  FDate:=fJSON.Int64s['date'];
+  FChat:=TTelegramChatObj.CreateFromJSONObject(fJSON.Find('chat', jtObject) as TJSONObject) as TTelegramChatObj;
+  FUser:=TTelegramUserObj.CreateFromJSONObject(fJSON.Find('user', jtObject) as TJSONObject) as TTelegramUserObj;
+  FActorChat:=TTelegramChatObj.CreateFromJSONObject(fJSON.Find('actor_chat', jtObject) as TJSONObject) as TTelegramChatObj;
+  FOldReactions:=TTelegramReactionTypeList.Create;
+  FNewReactions:=TTelegramReactionTypeList.Create;
+
+  lJSONArray := fJSON.Find('old_reaction', jtArray) as TJSONArray;
+  if Assigned(lJSONArray) then
+    for lJSONEnum in lJSONArray do
+      FOldReactions.Add(TTelegramReactionType.CreateFromJSONObject(
+        lJSONEnum.Value as TJSONObject) as TTelegramReactionType);
+
+  lJSONArray := fJSON.Find('new_reaction', jtArray) as TJSONArray;
+  if Assigned(lJSONArray) then
+    for lJSONEnum in lJSONArray do
+      FNewReactions.Add(TTelegramReactionType.CreateFromJSONObject(
+        lJSONEnum.Value as TJSONObject) as TTelegramReactionType);
+end;
+
+destructor TTelegramMessageReactionUpdated.Destroy;
+begin
+  FChat.Free;
+  FUser.Free;
+  FActorChat.Free;
+  FOldReactions.Free;
+  FNewReactions.Free;
+  inherited Destroy;
+end;
+
+{ TTelegramMessageReactionCountUpdated }
+
+constructor TTelegramMessageReactionCountUpdated.Create(JSONObject: TJSONObject);
+var
+  lJSONArray: TJSONArray;
+  lJSONEnum: TJSONEnum;
+begin
+  inherited Create(JSONObject);
+  FMessageID:=fJSON.Integers['message_id'];
+  FDate:=fJSON.Int64s['date'];
+  FChat:=TTelegramChatObj.CreateFromJSONObject(fJSON.Find('chat', jtObject) as TJSONObject) as TTelegramChatObj;
+  FReactions:=TTelegramReactionCountList.Create;
+
+  lJSONArray := fJSON.Find('reactions', jtArray) as TJSONArray;
+  if Assigned(lJSONArray) then
+    for lJSONEnum in lJSONArray do
+      FReactions.Add(TTelegramReactionCount.CreateFromJSONObject(
+        lJSONEnum.Value as TJSONObject) as TTelegramReactionCount);
+end;
+
+destructor TTelegramMessageReactionCountUpdated.Destroy;
+begin
+  FChat.Free;
+  FReactions.Free;
+  inherited Destroy;
+end;
+
 { TTelegramBusinessConnectionObj }
 
 constructor TTelegramBusinessConnectionObj.Create(JSONObject: TJSONObject);
@@ -1187,6 +1359,22 @@ function TTelegramUpdateObj.GetInlineQuery: TTelegramInlineQueryObj;
 begin
   if FUpdateType=utInlineQuery then
     Result:=TTelegramInlineQueryObj(FUpdateParameter)
+  else
+    Result:=nil;
+end;
+
+function TTelegramUpdateObj.GetMessageReaction: TTelegramMessageReactionUpdated;
+begin
+  if FUpdateType=utMessageReaction then
+    Result:=TTelegramMessageReactionUpdated(FUpdateParameter)
+  else
+    Result:=nil;
+end;
+
+function TTelegramUpdateObj.GetMessageReactionCount: TTelegramMessageReactionCountUpdated;
+begin
+  if FUpdateType=utMessageReactionCount then
+    Result:=TTelegramMessageReactionCountUpdated(FUpdateParameter)
   else
     Result:=nil;
 end;


### PR DESCRIPTION
### Motivation
- Add first-class support for Telegram message reactions so the library can receive and expose reaction-related updates.  
- Surface reaction events to consumers so apps can react to individual reaction changes and aggregated reaction counts.

### Description
- Added new data models `TTelegramReactionType`, `TTelegramReactionCount`, `TTelegramMessageReactionUpdated` and `TTelegramMessageReactionCountUpdated` and corresponding lists in `tgtypes.pas` to represent reaction payloads and counts.  
- Extended `TUpdateType` with `utMessageReaction` and `utMessageReactionCount`, updated `UpdateTypeAliases` and `UpdateTypeClasses`, and added `MessageReaction` / `MessageReactionCount` properties and getters on `TTelegramUpdateObj` in `tgtypes.pas`.  
- Implemented JSON parsing constructors/destructors for the new types to build reaction objects from incoming update JSON in `tgtypes.pas`.  
- Exposed new events `TMessageReactionEvent` and `TMessageReactionCountEvent`, added fields/properties `OnReceiveMessageReaction` and `OnReceiveMessageReactionCount`, implemented `DoReceiveMessageReaction` and `DoReceiveMessageReactionCount` handlers, and wired dispatch for the new update kinds in `tgsendertypes.pas`.
