### PR TITLE
Add support for Message.quote in tgtypes

### DIFF
--- a/fptelegram.lpk
+++ b/fptelegram.lpk
@@ -23,7 +23,7 @@
     </CompilerOptions>
     <Description Value="Telegram bots API library"/>
     <License Value="MIT License"/>
-    <Version Release="8"/>
+    <Version Release="9"/>
     <Files Count="6">
       <Item1>
         <Filename Value="tgsendertypes.pas"/>

--- a/test/testtelegram.pas
+++ b/test/testtelegram.pas
@@ -99,6 +99,13 @@ type
     procedure ReceiveUpdate;
   end;
 
+  { TTestMessageQuote }
+
+  TTestMessageQuote=class(TTestCase)
+  published
+    procedure ParseMessageQuote;
+  end;
+
   { TTestPayments }
 
   TTestPayments=class(TTestTelegramClass)
@@ -359,6 +366,55 @@ begin
       AssertEquals(3, aReactionCountUpdate.Reactions[0].TotalCount);
       AssertEquals(Ord(rtReactionTypeEmoji), Ord(aReactionCountUpdate.Reactions[0].ReactionType.TypeEnum));
       AssertEquals('❤️', aReactionCountUpdate.Reactions[0].ReactionType.Emoji);
+    finally
+      aUpdateObj.Free;
+    end;
+  finally
+    aJSONData.Free;
+  end;
+end;
+
+{ TTestMessageQuote }
+
+procedure TTestMessageQuote.ParseMessageQuote;
+const
+  MessageWithQuoteJSON =
+    '{' +
+      '"update_id":1002,' +
+      '"message":{' +
+        '"message_id":55,' +
+        '"date":1700000200,' +
+        '"chat":{"id":77,"type":"private","first_name":"Test"},' +
+        '"from":{"id":88,"is_bot":false,"first_name":"Alice"},' +
+        '"text":"Reply with quote",' +
+        '"quote":{' +
+          '"position":6,' +
+          '"text":"quoted",' +
+          '"is_manual":true,' +
+          '"entities":[{"type":"bold","offset":0,"length":6}]' +
+        '}' +
+      '}' +
+    '}';
+var
+  aUpdateObj: TTelegramUpdateObj;
+  aMessage: TTelegramMessageObj;
+  aJSONData: TJSONData;
+begin
+  aJSONData:=GetJSON(MessageWithQuoteJSON);
+  try
+    aUpdateObj:=TTelegramUpdateObj.Create(aJSONData as TJSONObject);
+    try
+      AssertEquals(Ord(utMessage), Ord(aUpdateObj.UpdateType));
+      aMessage:=aUpdateObj.Message;
+      AssertNotNull('Message should be assigned', aMessage);
+      AssertNotNull('Quote should be assigned', aMessage.Quote);
+      AssertEquals(6, aMessage.Quote.Position);
+      AssertEquals('quoted', aMessage.Quote.Text);
+      AssertTrue('Quote.IsManual should be True', aMessage.Quote.IsManual);
+      AssertEquals(1, aMessage.Quote.Entities.Count);
+      AssertEquals('bold', aMessage.Quote.Entities[0].TypeEntity);
+      AssertEquals(0, aMessage.Quote.Entities[0].Offset);
+      AssertEquals(6, aMessage.Quote.Entities[0].Length);
     finally
       aUpdateObj.Free;
     end;
@@ -694,6 +750,6 @@ end;
 
 initialization
   RegisterTests([TTestSender, TTestSenderProcedure, TTestProxySender, TTestReceiveLongPolling,
-    TTestPayments, TTestReactionUpdates]);
+    TTestPayments, TTestReactionUpdates, TTestMessageQuote]);
 
 end.

--- a/tgtypes.pas
+++ b/tgtypes.pas
@@ -10,6 +10,7 @@ uses
 type
   TTelegramUpdateObj = class;
   TTelegramMessageObj = class;
+  TTelegramTextQuote = class;
   TTelegramMessageEntityObj = class;
   TTelegramChatMemberUpdated = class;
   TTelegramInlineQueryObj = class;
@@ -125,6 +126,7 @@ type
     FMessageThreadID: Integer;
     FPhoto: TTelegramPhotoSizeList;
     FReplyToMessage: TTelegramMessageObj;
+    FQuote: TTelegramTextQuote;
     FSuccessfulPayment: TTelegramSuccessfulPayment;
     FViaBot: TTelegramUserObj;
     FVideo: TTelegramVideo;
@@ -146,6 +148,7 @@ type
     property ForwardFromMessageID: Integer read FForwardFromMessageID;
     property ChatId: Int64 read fChatId;
     property ReplyToMessage: TTelegramMessageObj read FReplyToMessage;
+    property Quote: TTelegramTextQuote read FQuote;
     property Text: string read fText;
     property Entities: TTelegramUpdateObjList read fEntities;
     property Document: TTelegramDocument read FDocument;
@@ -160,6 +163,23 @@ type
     property MediaGroupID: String read FMediaGroupID;
     property MessageThreadID: Integer read FMessageThreadID;
     property IsTopicMessage: Boolean read FIsTopicMessage;
+  end;
+
+  { TTelegramTextQuote }
+
+  TTelegramTextQuote = class(TTelegramObj)
+  private
+    FPosition: Integer;
+    FText: String;
+    FEntities: TTelegramUpdateObjList;
+    FIsManual: Boolean;
+  public
+    constructor Create(JSONObject: TJSONObject); override;
+    destructor Destroy; override;
+    property Position: Integer read FPosition;
+    property Text: String read FText;
+    property Entities: TTelegramUpdateObjList read FEntities;
+    property IsManual: Boolean read FIsManual;
   end;
 
   { TTelegramMessageEntityObj }
@@ -1477,6 +1497,9 @@ begin
     TTelegramMessageObj.CreateFromJSONObject(fJSON.Find('reply_to_message', jtObject) as TJSONObject)
     as TTelegramMessageObj;
 
+  FQuote:=TTelegramTextQuote.CreateFromJSONObject(fJSON.Find('quote', jtObject) as TJSONObject)
+    as TTelegramTextQuote;
+
   lJSONArray := fJSON.Find('entities', jtArray) as TJSONArray;
   if Assigned(lJSONArray) then
     for lJSONEnum in lJSONArray do
@@ -1506,12 +1529,38 @@ begin
   FLocation.Free;
   FChat.Free;
   FReplyToMessage.Free;
+  FQuote.Free;
   FPhoto.Free;
   FDocument.Free;
   FAudio.Free;
   FVideo.Free;
   FVoice.Free;
   fEntities.Free;
+  inherited Destroy;
+end;
+
+{ TTelegramTextQuote }
+
+constructor TTelegramTextQuote.Create(JSONObject: TJSONObject);
+var
+  lJSONArray: TJSONArray;
+  lJSONEnum: TJSONEnum;
+begin
+  inherited Create(JSONObject);
+  FPosition:=fJSON.Get('position', 0);
+  FText:=fJSON.Get('text', EmptyStr);
+  FIsManual:=fJSON.Get('is_manual', False);
+  FEntities:=TTelegramUpdateObjList.Create;
+
+  lJSONArray := fJSON.Find('entities', jtArray) as TJSONArray;
+  if Assigned(lJSONArray) then
+    for lJSONEnum in lJSONArray do
+      FEntities.Add(TTelegramMessageEntityObj.CreateFromJSONObject(lJSONEnum.Value as TJSONObject) as TTelegramMessageEntityObj);
+end;
+
+destructor TTelegramTextQuote.Destroy;
+begin
+  FEntities.Free;
   inherited Destroy;
 end;
 


### PR DESCRIPTION
### Motivation

- Support Telegram Bot API `message.quote` (TextQuote) in the library so message objects expose the new `quote` payload.

### Description

- Added a new `TTelegramTextQuote` type with fields `Position`, `Text`, `Entities` and `IsManual` and implemented parsing and cleanup in its constructor/destructor.
- Extended `TTelegramMessageObj` with an `FQuote` field and `Quote` property, added parsing of `message.quote` in the constructor, and freed `FQuote` in the destructor.
- Added a unit test `TTestMessageQuote.ParseMessageQuote` which verifies parsing of `quote` including entity parsing and `is_manual` flag, and registered the test in the test suite.
- Modified files: `tgtypes.pas` and `test/testtelegram.pas` to implement the feature and tests.

