### PR TITLE
Add ExternalReply support to TTelegramMessageObj and add test

### DIFF
--- a/fptelegram.lpk
+++ b/fptelegram.lpk
@@ -23,7 +23,7 @@
     </CompilerOptions>
     <Description Value="Telegram bots API library"/>
     <License Value="MIT License"/>
-    <Version Release="9"/>
+    <Version Release="10"/>
     <Files Count="6">
       <Item1>
         <Filename Value="tgsendertypes.pas"/>

--- a/test/testtelegram.pas
+++ b/test/testtelegram.pas
@@ -104,6 +104,7 @@ type
   TTestMessageQuote=class(TTestCase)
   published
     procedure ParseMessageQuote;
+    procedure ParseMessageExternalReply;
   end;
 
   { TTestPayments }
@@ -415,6 +416,49 @@ begin
       AssertEquals('bold', aMessage.Quote.Entities[0].TypeEntity);
       AssertEquals(0, aMessage.Quote.Entities[0].Offset);
       AssertEquals(6, aMessage.Quote.Entities[0].Length);
+    finally
+      aUpdateObj.Free;
+    end;
+  finally
+    aJSONData.Free;
+  end;
+end;
+
+procedure TTestMessageQuote.ParseMessageExternalReply;
+const
+  MessageWithExternalReplyJSON =
+    '{' +
+      '"update_id":1003,' +
+      '"message":{' +
+        '"message_id":56,' +
+        '"date":1700000300,' +
+        '"chat":{"id":77,"type":"private","first_name":"Test"},' +
+        '"from":{"id":88,"is_bot":false,"first_name":"Alice"},' +
+        '"text":"Reply to external message",' +
+        '"external_reply":{' +
+          '"origin":{' +
+            '"type":"user",' +
+            '"date":1700000290,' +
+            '"sender_user":{"id":99,"is_bot":false,"first_name":"Bob"}' +
+          '}' +
+        '}' +
+      '}' +
+    '}';
+var
+  aUpdateObj: TTelegramUpdateObj;
+  aMessage: TTelegramMessageObj;
+  aJSONData: TJSONData;
+begin
+  aJSONData:=GetJSON(MessageWithExternalReplyJSON);
+  try
+    aUpdateObj:=TTelegramUpdateObj.Create(aJSONData as TJSONObject);
+    try
+      AssertEquals(Ord(utMessage), Ord(aUpdateObj.UpdateType));
+      aMessage:=aUpdateObj.Message;
+      AssertNotNull('Message should be assigned', aMessage);
+      AssertNotNull('ExternalReply should be assigned', aMessage.ExternalReply);
+      AssertTrue('ExternalReply JSON should contain origin type',
+        Pos('"type":"user"', aMessage.ExternalReply.AsString)>0);
     finally
       aUpdateObj.Free;
     end;

--- a/test/testtelegram.pas
+++ b/test/testtelegram.pas
@@ -458,7 +458,7 @@ begin
       AssertNotNull('Message should be assigned', aMessage);
       AssertNotNull('ExternalReply should be assigned', aMessage.ExternalReply);
       AssertTrue('ExternalReply JSON should contain origin type',
-        Pos('"type":"user"', aMessage.ExternalReply.AsString)>0);
+        Pos('"type" : "user"', aMessage.ExternalReply.AsString)>0);
     finally
       aUpdateObj.Free;
     end;

--- a/tgtypes.pas
+++ b/tgtypes.pas
@@ -11,6 +11,7 @@ type
   TTelegramUpdateObj = class;
   TTelegramMessageObj = class;
   TTelegramTextQuote = class;
+  TTelegramExternalReplyInfo = class;
   TTelegramMessageEntityObj = class;
   TTelegramChatMemberUpdated = class;
   TTelegramInlineQueryObj = class;
@@ -114,6 +115,7 @@ type
     FContact: TTelegramContact;
     FDate: Int64;
     FDocument: TTelegramDocument;
+    FExternalReply: TTelegramExternalReplyInfo;
     FForwardFrom: TTelegramUserObj;
     FForwardFromChat: TTelegramChatObj;
     FForwardFromMessageID: LongInt;
@@ -152,6 +154,7 @@ type
     property Text: string read fText;
     property Entities: TTelegramUpdateObjList read fEntities;
     property Document: TTelegramDocument read FDocument;
+    property ExternalReply: TTelegramExternalReplyInfo read FExternalReply;
     property Location: TTelegramLocation read FLocation;
     property Photo: TTelegramPhotoSizeList read FPhoto;
     property Audio: TTelegramAudio read FAudio;
@@ -163,6 +166,13 @@ type
     property MediaGroupID: String read FMediaGroupID;
     property MessageThreadID: Integer read FMessageThreadID;
     property IsTopicMessage: Boolean read FIsTopicMessage;
+  end;
+
+  { TTelegramExternalReplyInfo }
+
+  TTelegramExternalReplyInfo = class(TTelegramObj)
+  public
+    constructor Create(JSONObject: TJSONObject); override;
   end;
 
   { TTelegramTextQuote }
@@ -1478,6 +1488,8 @@ begin
   fChatId := fJSON.Objects['chat'].Int64s['id']; // deprecated?
   FFrom:=TTelegramUserObj.CreateFromJSONObject(fJSON.Find('from', jtObject) as TJSONObject) as TTelegramUserObj;
   FDocument := TTelegramDocument.CreateFromJSONObject(fJSON.Find('document', jtObject) as TJSONObject) as TTelegramDocument;
+  FExternalReply := TTelegramExternalReplyInfo.CreateFromJSONObject(
+    fJSON.Find('external_reply', jtObject) as TJSONObject) as TTelegramExternalReplyInfo;
   FVideo := TTelegramVideo.CreateFromJSONObject(fJSON.Find('video', jtObject) as TJSONObject) as TTelegramVideo;
   FAudio := TTelegramAudio.CreateFromJSONObject(fJSON.Find('audio', jtObject) as TJSONObject) as TTelegramAudio;
   FVoice := TTelegramVoice.CreateFromJSONObject(fJSON.Find('voice', jtObject) as TJSONObject) as TTelegramVoice; 
@@ -1532,11 +1544,19 @@ begin
   FQuote.Free;
   FPhoto.Free;
   FDocument.Free;
+  FExternalReply.Free;
   FAudio.Free;
   FVideo.Free;
   FVoice.Free;
   fEntities.Free;
   inherited Destroy;
+end;
+
+{ TTelegramExternalReplyInfo }
+
+constructor TTelegramExternalReplyInfo.Create(JSONObject: TJSONObject);
+begin
+  inherited Create(JSONObject);
 end;
 
 { TTelegramTextQuote }


### PR DESCRIPTION
### Motivation

- Support new Telegram message field `external_reply` by exposing it in the message object hierarchy so external reply metadata is available to consumers.

### Description

- Introduce `TTelegramExternalReplyInfo` class and add `ExternalReply` property to `TTelegramMessageObj` to represent the `external_reply` JSON object. 
- Parse `external_reply` in `TTelegramMessageObj.Create` using `CreateFromJSONObject` and free it in the destructor. 
- Add unit test `TTestMessageQuote.ParseMessageExternalReply` in `test/testtelegram.pas` to validate that `ExternalReply` is assigned and contains the expected origin type in its JSON.
------
