### PR TITLE
Add style support for keyboard and inline keyboard buttons

### DIFF
--- a/fptelegram.lpk
+++ b/fptelegram.lpk
@@ -23,7 +23,7 @@
     </CompilerOptions>
     <Description Value="Telegram bots API library"/>
     <License Value="MIT License"/>
-    <Version Release="10"/>
+    <Version Release="11"/>
     <Files Count="6">
       <Item1>
         <Filename Value="tgsendertypes.pas"/>

--- a/test/testtelegram.pas
+++ b/test/testtelegram.pas
@@ -85,6 +85,13 @@ type
     procedure ParseMessageReactionCountUpdate;
   end;
 
+  { TTestSenderTypes }
+
+  TTestSenderTypes=class(TTestCase)
+  published
+    procedure KeyboardButtonsStyle;
+  end;
+
   { TTestReceiveLongPollingBase }
   { Test receiving updates via longpolling from the test bot. Please send test messages to the bot
     immediately before running the test! }
@@ -467,6 +474,38 @@ begin
   end;
 end;
 
+{ TTestSenderTypes }
+
+procedure TTestSenderTypes.KeyboardButtonsStyle;
+var
+  aReplyMarkup: TReplyMarkup;
+  aReplyButtons: TKeyboardButtons;
+  aInlineButtons: TInlineKeyboardButtons;
+  aReplyButton: TKeyboardButton;
+  aInlineButton: TInlineKeyboardButton;
+begin
+  aReplyMarkup:=TReplyMarkup.Create;
+  try
+    aReplyButtons:=aReplyMarkup.CreateReplyKeyboard.Add;
+    aReplyButton:=TKeyboardButton.Create('Reply button');
+    aReplyButton.Style:='primary';
+    aReplyButtons.Add(aReplyButton);
+
+    aInlineButtons:=aReplyMarkup.CreateInlineKeyBoard.Add;
+    aInlineButton:=TInlineKeyboardButton.Create('Inline button');
+    aInlineButton.Callback_Data:='cb';
+    aInlineButton.Style:='secondary';
+    aInlineButtons.Add(aInlineButton);
+
+    AssertEquals('primary', aReplyButton.Style);
+    AssertEquals('secondary', aInlineButton.Style);
+    AssertTrue('Reply keyboard JSON should contain style', Pos('"style" : "primary"', aReplyMarkup.AsJSON)>0);
+    AssertTrue('Inline keyboard JSON should contain style', Pos('"style" : "secondary"', aReplyMarkup.AsJSON)>0);
+  finally
+    aReplyMarkup.Free;
+  end;
+end;
+
 { TTestSender }
 
 procedure TTestSender.SetUp;
@@ -794,6 +833,6 @@ end;
 
 initialization
   RegisterTests([TTestSender, TTestSenderProcedure, TTestProxySender, TTestReceiveLongPolling,
-    TTestPayments, TTestReactionUpdates, TTestMessageQuote]);
+    TTestPayments, TTestReactionUpdates, TTestMessageQuote, TTestSenderTypes]);
 
 end.

--- a/tgsendertypes.pas
+++ b/tgsendertypes.pas
@@ -108,13 +108,16 @@ type
   private
     function GetRequestContact: Boolean;
     function GetRequestLocation: Boolean;
+    function GetStyle: String;
     function Gettext: String;
     procedure SetRequestContact(AValue: Boolean);
     procedure SetRequestLocation(AValue: Boolean);
+    procedure SetStyle(const AValue: String);
     procedure Settext(AValue: String);
   public
     constructor Create(const AText: String);
     property text: String read Gettext write Settext;
+    property Style: String read GetStyle write SetStyle; // Optional
     property RequestContact: Boolean read GetRequestContact write SetRequestContact; // Optional
     property RequestLocation: Boolean read GetRequestLocation write SetRequestLocation; // Optional
   end;
@@ -142,9 +145,11 @@ type
     function Getcallback_data: String;
     function Getswitch_inline_query: String;
     function Getswitch_inline_query_current_chat: String;
+    function GetStyle: String;
     function Gettext: String;
     function Geturl: String;
     procedure Setcallback_data(AValue: String);
+    procedure SetStyle(AValue: String);
     procedure Setswitch_inline_query(AValue: String);
     procedure Setswitch_inline_query_current_chat(AValue: String);
     procedure Settext(AValue: String);
@@ -152,6 +157,7 @@ type
   public
     constructor Create(const AText: String);
     property text: String read Gettext write Settext;
+    property Style: String read GetStyle write SetStyle;
     property url: String read Geturl write Seturl;
     property callback_data: String read Getcallback_data write Setcallback_data;
     property switch_inline_query: String read Getswitch_inline_query write Setswitch_inline_query;
@@ -856,6 +862,7 @@ const
   s_OneTimeKeyboard = 'one_time_keyboard';
   s_RequestContact = 'request_contact';
   s_RequestLocation = 'request_location';
+  s_Style = 'style';
   s_SwitchInlineQuery = 'switch_inline_query';
   s_CallbackData = 'callback_data';
   s_SwitchInlineQueryCurrentChat = 's_switch_inline_query_current_chat';
@@ -1697,6 +1704,11 @@ begin
   Result:=Strings[s_text];
 end;
 
+function TKeyboardButton.GetStyle: String;
+begin
+  Result:=Strings[s_Style];
+end;
+
 procedure TKeyboardButton.SetRequestContact(AValue: Boolean);
 begin
   Booleans[s_RequestContact]:=AValue;
@@ -1710,6 +1722,11 @@ end;
 procedure TKeyboardButton.Settext(AValue: String);
 begin
   Strings[s_text]:=AValue;
+end;
+
+procedure TKeyboardButton.SetStyle(const AValue: String);
+begin
+  Strings[s_Style]:=AValue;
 end;
 
 constructor TKeyboardButton.Create(const AText: String);
@@ -1910,6 +1927,11 @@ begin
   Strings[s_text]:=AValue;
 end;
 
+procedure TInlineKeyboardButton.SetStyle(AValue: String);
+begin
+  Strings[s_Style]:=AValue;
+end;
+
 procedure TInlineKeyboardButton.Setcallback_data(AValue: String);
 begin
   CheckOptnlAndSet(s_callbackdata, AValue);
@@ -1918,6 +1940,11 @@ end;
 function TInlineKeyboardButton.Geturl: String;
 begin
   Result:=Strings[s_url];
+end;
+
+function TInlineKeyboardButton.GetStyle: String;
+begin
+  Result:=Strings[s_Style];
 end;
 
 function TInlineKeyboardButton.CheckOptnlNull: Boolean;


### PR DESCRIPTION
### Motivation
- Telegram introduced a `style` field for keyboard buttons and the library needs to expose it on the button objects so it is serialized into API JSON.
- Tests should cover setting the `style` value and ensure JSON output contains the `style` key for reply and inline keyboards.

### Description
- Added a `Style: String` property to `TKeyboardButton` and `TInlineKeyboardButton` in `tgsendertypes.pas` with corresponding `GetStyle`/`SetStyle` methods that read/write the `s_Style` JSON key.
- Introduced constant `s_Style = 'style'` in `tgsendertypes.pas` to represent the JSON key.
- Implemented getters and setters so `Style` is serialized via the existing `Strings[...]` JSON mapping.
- Added unit test `TTestSenderTypes.KeyboardButtonsStyle` in `test/testtelegram.pas` which sets `Style` on both button types, asserts property values, verifies `style` appears in the markup JSON, and registered the test class in the test initialization list.

### Testing
- Added automated unit test `TTestSenderTypes.KeyboardButtonsStyle` to `test/testtelegram.pas` (not executed in this environment).
- Attempted to compile/run tests with `fpc -Fu. -Fu./test test/console.lpr` but the Free Pascal compiler is not available here (`fpc: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b86b35b3f08328b7b65c9463703490)